### PR TITLE
Add simple Gemini API client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Investor-Agent
+
+This repository demonstrates a simple Python client for Google’s Gemini API.
+
+## Requirements
+
+- Python 3.8+
+- `requests` library
+
+## Usage
+
+Set the `GEMINI_API_KEY` environment variable with your API key from Google Cloud.
+
+Run the client:
+
+```bash
+python gemini_client.py "Write your prompt here"
+```
+
+The script prints the JSON response from the API.

--- a/gemini_client.py
+++ b/gemini_client.py
@@ -1,0 +1,38 @@
+import os
+import requests
+
+API_KEY = os.environ.get('GEMINI_API_KEY')
+if not API_KEY:
+    raise ValueError('Set the GEMINI_API_KEY environment variable with your API key.')
+
+API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent'
+
+
+def generate_content(prompt: str) -> dict:
+    """Generate content from Gemini API using the provided prompt."""
+    headers = {'Content-Type': 'application/json'}
+    params = {'key': API_KEY}
+    data = {
+        'contents': [
+            {
+                'parts': [
+                    {'text': prompt}
+                ]
+            }
+        ]
+    }
+    response = requests.post(API_URL, headers=headers, params=params, json=data)
+    response.raise_for_status()
+    return response.json()
+
+
+if __name__ == '__main__':
+    import sys
+
+    if len(sys.argv) < 2:
+        print('Usage: python gemini_client.py <prompt>')
+        sys.exit(1)
+
+    prompt = ' '.join(sys.argv[1:])
+    result = generate_content(prompt)
+    print(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- add Gemini API example client with `requests`
- document usage and requirements
- ignore cache and environment files
- add dependency list for installation

## Testing
- `pip install -r requirements.txt`
- `GEMINI_API_KEY=dummy python3 gemini_client.py "Hello"` *(fails: 400 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_6861f30c4dbc832aa367a2fe316ef8ae